### PR TITLE
release 0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rn-fetch-blob",
-  "version": "0.12.0",
+  "name": "@oguennec/rn-fetch-blob",
+  "version": "0.12.1",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
See [issue-654](https://github.com/joltup/rn-fetch-blob/issues/654)

Generate release 0.12.1 of **@oguennec/rn-fetch-blob** instead of pointing to head of original master branch